### PR TITLE
Switch from gfx::Span to std::span

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(BallSimulatorGl
     src/application.cpp src/application.hpp
     src/ballsimulatorgl.cpp src/ballsimulatorgl.hpp
     src/main.cpp)
-set_property(TARGET BallSimulatorGl PROPERTY CXX_STANDARD 14)
+set_property(TARGET BallSimulatorGl PROPERTY CXX_STANDARD 20)
 target_link_libraries(BallSimulatorGl BallSimulator glfw OpenGL::GL)
 target_compile_definitions(BallSimulatorGl PRIVATE $<$<PLATFORM_ID:Darwin>:GL_SILENCE_DEPRECATION>)
 

--- a/src/ballsimulatorgl.cpp
+++ b/src/ballsimulatorgl.cpp
@@ -37,13 +37,14 @@ gfx::Mesh BallSimulatorGl::generate_filled_circle(gfx::Renderer& render, float r
 }
 
 gfx::Mesh BallSimulatorGl::generate_filled_rect(gfx::Renderer& render, const Extent<float>& rect) {
-    constexpr std::array<uint16_t, 6> indices{ 0, 1, 2, 2, 3, 0 };
-    const gfx::Vertex vertices[4] = {
+    constexpr std::array<uint16_t, 6> indices{
+        0, 1, 2, 2, 3, 0
+    };
+    const std::array<gfx::Vertex, 4> vertices{{
         { rect.bottom_left() }, { rect.bottom_right() },
         { rect.top_right() }, { rect.top_left() }
-    };
-
-    return render.create_mesh(gfx::Span<gfx::Vertex>(vertices, 4), indices);
+    }};
+    return render.create_mesh(vertices, indices);
 }
 
 
@@ -125,7 +126,7 @@ void BallSimulatorGl::render(double deltaTime) {
 #endif
         static void (*inner)(const BallSimulator::CollisionQuadtree&) =
                 [](const BallSimulator::CollisionQuadtree& innerTree) {
-            
+
             const auto& bounds = innerTree.bounds();
             if (innerTree.has_child_nodes()) {
                 quads.push_back({

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -31,7 +31,7 @@ void Renderer::new_frame() {
     glClear(GL_COLOR_BUFFER_BIT);
 }
 
-Mesh Renderer::create_mesh(const Span<Vertex> vertices, const Span<uint16_t> indices, PrimitiveType mode) {
+Mesh Renderer::create_mesh(std::span<const Vertex> vertices, std::span<const uint16_t> indices, PrimitiveType mode) {
     GLuint bufferIds[2];
     glGenBuffers(2, bufferIds);
     glBindBuffer(GL_ARRAY_BUFFER, bufferIds[Mesh::VERTEX]);
@@ -119,7 +119,7 @@ void Renderer::draw_mesh(Mesh& mesh, const Instance& instance) {
     gl_inner_unbind();
 }
 
-void Renderer::draw_mesh(Mesh& mesh, const Span<Instance> instances) {
+void Renderer::draw_mesh(Mesh& mesh, std::span<const Instance> instances) {
     assert(mesh.valid());
     assert(instances.data());
 

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -4,6 +4,7 @@
 #include "rectangle.hpp"
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <limits>
 #include <algorithm>
 #include <cassert>
@@ -113,45 +114,6 @@ namespace gfx {
         int _numindices;
     };
 
-    template <typename ElementType>
-    struct Span {
-        typedef const ElementType element_type;
-        typedef element_type* pointer;
-        typedef element_type& reference;
-        typedef pointer iterator;
-        typedef std::size_t size_type;
-        typedef std::ptrdiff_t difference_type;
-
-    private:
-        pointer const _data;
-        const size_type _length;
-
-    public:
-        constexpr Span() noexcept: _data(nullptr), _length(0u) {}
-        constexpr Span(pointer data, size_type count) : _data(data), _length(count) {}
-        constexpr Span(pointer first, pointer last) : _data(first), _length(last - first) {}
-        template <typename T, std::size_t N>
-        constexpr Span(const std::array<T, N>& array) noexcept : _data(array.data()), _length(N) {}
-        template <typename T>
-        constexpr Span(const std::initializer_list<T>& list) noexcept : _data(list.begin()), _length(list.size()) {}
-        template <typename C>
-        constexpr Span(const C& c) : _data(c.data()), _length(c.size()) {}
-
-        constexpr Span(const Span& other) noexcept = default;
-        ~Span() noexcept = default;
-        constexpr Span& operator =(const Span& other) noexcept = default;
-
-        constexpr reference operator [](size_type idx) const noexcept { return _data[idx]; }
-
-        constexpr pointer data() const noexcept { return _data; }
-        constexpr size_type size() const noexcept { return _length; }
-
-        constexpr iterator begin() const noexcept { return data(); }
-        constexpr iterator end() const noexcept { return data() + size(); }
-
-    private:
-    };
-
     class Renderer {
     public:
         Renderer(const colorf& clear = colorf::black());
@@ -161,11 +123,11 @@ namespace gfx {
 
         void new_frame();
 
-        Mesh create_mesh(const Span<Vertex> vertices, const Span<uint16_t> indices,
+        Mesh create_mesh(std::span<const Vertex> vertices, std::span<const uint16_t> indices,
             PrimitiveType mode = PrimitiveType::TRIANGLES);
         void delete_mesh(Mesh& mesh);
 
         void draw_mesh(Mesh& mesh, const Instance& instance);
-        void draw_mesh(Mesh& mesh, const Span<Instance> instances);
+        void draw_mesh(Mesh& mesh, const std::span<const Instance> instances);
     };
 }


### PR DESCRIPTION
Replaces homebrew span object & its usages with the STL std::span, this is cleaner but bumps the C++ standard requirement from C++14 to C++20 for at minimum the OpenGL test program.

Close this PR if C++14 compatibility is preferred.